### PR TITLE
fix: padding calcs breaking for commands signature with more than 30 chars

### DIFF
--- a/src/commands/Command.ts
+++ b/src/commands/Command.ts
@@ -19,7 +19,7 @@ export abstract class Command<Arguments = Record<string, string | null | string[
     const { opts } = parseDescriptions(this.globalOptions) as any;
     let optsList = "";
     for(const name in opts) {
-      const padding = ' '.repeat(20 - name.length);
+      const padding = ' '.repeat(Math.max(0, 20 - name.length));
       optsList += `  ${chalk.green(name)}${padding}${opts[name] ?? ""}\n`;
     }
     console.log(`${chalk.yellow("Options")}:\n${optsList}`);
@@ -147,7 +147,7 @@ export abstract class Command<Arguments = Record<string, string | null | string[
       let hasAtleastOneArgument = false;
       for(const name in args) {
         hasAtleastOneArgument = true;
-        const padding = ' '.repeat(20 - name.length);
+        const padding = ' '.repeat(Math.max(0, 20 - name.length));
         const description = args[name];
         argsList += `  ${chalk.green(name)}${padding}${description ?? ""}\n`;
       }
@@ -156,7 +156,7 @@ export abstract class Command<Arguments = Record<string, string | null | string[
     
     let optsList = "";
     for(const name in opts) {
-      const padding = ' '.repeat(20 - name.length);
+      const padding = ' '.repeat(Math.max(0, 20 - name.length));
       optsList += `  ${chalk.green(name)}${padding}${opts[name] ?? ""}\n`;
     }
     console.log(`${chalk.yellow("Options")}:\n${optsList}`);

--- a/src/commands/ListCommands.ts
+++ b/src/commands/ListCommands.ts
@@ -14,7 +14,7 @@ export default class ListCommands extends Command {
   async handle() {
     console.log("Available Commands:\n");
     this.samerArtisan.$resolvedCommands.forEach(command => {
-      const padding = ' '.repeat(30 - command.base.length);
+      const padding = ' '.repeat(Math.max(0, 30 - command.base.length));
       console.log(`  ${green(command.base)}${padding}${command.description}`);
     });
   }


### PR DESCRIPTION
I was casually writing a small CLI and bumped into this issue 👍  